### PR TITLE
Increase contrast between text and background

### DIFF
--- a/client/src/pages/Landing.js
+++ b/client/src/pages/Landing.js
@@ -4,6 +4,8 @@ import Navbar from "../components/Navbar";
 import Footer from "../components/Footer";
 import { NavLink } from "react-router-dom";
 
+<!-- See comment about contrast between text and background image -->
+
 //Yian
 function Landing() {
   return (


### PR DESCRIPTION
Depending on the size of your screen, the grey text may show up in front of a dark part of the background image and the white text may show up in front of a light part of the background (like in the footer) — suggest adding a drop shadow or solid container to the text to increase contrast.