### PR TITLE
Suggest adding gatekeeper for user info

### DIFF
--- a/client/src/components/Profile.js
+++ b/client/src/components/Profile.js
@@ -9,6 +9,8 @@ import {
 import { FaRegCalendarCheck } from "react-icons/fa";
 import bulb2 from "../assets/images/bulb2.png";
 
+<!-- See comment about gatekeeper -->
+
 /**
  * Amanda Au-Yeung
  * profile of student


### PR DESCRIPTION
I noticed that on the landing page, I am able to view "My Profile" and "Account Settings" and "Book Class" before creating an account and logging into it. Suggest redirecting people who try to access that info to the login page.